### PR TITLE
Use \fP instead of \fR when ending code blocks

### DIFF
--- a/lib/marked-man.js
+++ b/lib/marked-man.js
@@ -110,7 +110,7 @@ InlineLexer.prototype.roff_output = function(src) {
       src = src.substring(cap[0].length);
       out += '\\fB'
         + resc(cap[2], true)
-        + '\\fR';
+        + '\\fP';
       continue;
     }
 


### PR DESCRIPTION
\fR switches to the roman font, making this only work if the font
was previously roman. With \fP, it switches to the previous font,
working in both headlines as well as regular paragraph text.

Fixes #4