### PR TITLE
Exclude unneeded filed from distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,11 @@
   "name": "marked-man",
   "version": "0.2.0",
   "description": "wrapper adding manpage output to 'marked', inspired by 'ronn'",
+  "files": [
+    "lib",
+    "man",
+    "bin"
+  ],
   "main": "lib/marked-man.js",
   "bin": {
     "marked-man": "./bin/marked-man"


### PR DESCRIPTION
The `test` directory takes up a good chunk of disk space. By removing it, the distribution becomes downright tiny. This might seem excessive, but I'm thinking of including `marked-man` as a standard feature of something I work on, so having it be this much smaller would be lovely and much easier to justify.

```
4.0K    node_modules/marked-man/bin
12K     node_modules/marked-man/lib
4.0K    node_modules/marked-man/man
80K     node_modules/marked-man/test/man
76K     node_modules/marked-man/test/md
96K     node_modules/marked-man/test/out
256K    node_modules/marked-man/test
304K    node_modules/marked-man
```