### PR TITLE
Use SOURCE_DATE_EPOCH if available in the environment.

### DIFF
--- a/lib/marked-man.js
+++ b/lib/marked-man.js
@@ -414,6 +414,9 @@ function rparseHeader(str, options) {
 }
 function manDate(date) {
   date = new Date(date);
+  if (process.env.SOURCE_DATE_EPOCH) {
+    date = new Date(process.env.SOURCE_DATE_EPOCH * 1000);
+  }
   var month = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"][date.getMonth()];
   return month + " " + date.getFullYear();
 }


### PR DESCRIPTION
Whilst working on the Reproducible Builds effort [0], we noticed
that node-marked-man generated reproducible output. In particular,
it uses the current timestamp which varies between builds.

Patch attached that uses SOURCE_DATE_EPOCH[1] if that is exported
in the environment.

 [0] https://reproducible-builds.org/
 [1] https://reproducible-builds.org/specs/source-date-epoch/

Signed-off-by: Chris Lamb <chris@chris-lamb.co.uk>