### PR TITLE
Update to resolve issue between marked and marked-man.

### DIFF
--- a/lib/marked-man.js
+++ b/lib/marked-man.js
@@ -163,6 +163,9 @@ Parser.prototype.parse = function(src) {
     this.inline.outputLink = this.inline.html_outputLink;
   }
 
+  // NOTE marked.js Parser.tok() relies on a this.inlineText reference.
+  this.inlineText = this.inline;
+
   var out = '';
   while (this.next()) {
     out += this.tok();
@@ -287,7 +290,7 @@ Parser.prototype.roff_tok = function() {
     }
 
     /* deal with table format, add by gholk.
-     * use **tbl** macro format table in man page. 
+     * use **tbl** macro format table in man page.
      */
     case 'table': {
       var tblText = [],  // troff tbl macro text.
@@ -300,7 +303,7 @@ Parser.prototype.roff_tok = function() {
        *
        * set table border.
        *
-       * set expand to full screen. without expand, 
+       * set expand to full screen. without expand,
        * tbl sometimes mistake terminal width.
        * but expand is ugly sometimes...
        *
@@ -326,8 +329,8 @@ Parser.prototype.roff_tok = function() {
 
       /* run each row */
       for (var i=0; i<this.token.cells.length; i++) {
-        rowArray = [];  // new array store cells in a row. 
-        var thisRow = this.token.cells[i];  // pointer to old array. 
+        rowArray = [];  // new array store cells in a row.
+        var thisRow = this.token.cells[i];  // pointer to old array.
 
         /* run each cell */
         for (var j=0; j<thisRow.length; j++)


### PR DESCRIPTION
The marked lib Parser.tok routine relies on a reference to this.inlineText. This patch ensures that gets set up to avoid problems running with the latest versions of marked and marked-man.