### PR TITLE
marked should be in peerDependencies and not dependencies

### DIFF
--- a/bin/marked-man
+++ b/bin/marked-man
@@ -1,7 +1,5 @@
 #!/usr/bin/env node
 
-require('../'); // force bin/marked to require marked-man
-
 var main = require('marked/bin/marked');
 
 main(process.argv.slice(), function(err, code) {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "author": "Jérémy Lal <kapouer@melix.org>",
   "license": "MIT",
-  "dependencies": {
+  "peerDependencies": {
     "marked": "^0.3.2"
   }
 }


### PR DESCRIPTION
The [package.json](https://github.com/kapouer/marked-man/blob/master/package.json) file contains

```
  "dependencies": {
    "marked": "^0.3.2"
  }
```

but this should be

```
  "peerDependencies": {
    "marked": "^0.3.2"
  }
```

since [bin/marked-man](https://github.com/kapouer/marked-man/blob/master/bin/marked-man) is calling the marked *host package*. [Blog post about peer dependencies](https://nodejs.org/en/blog/npm/peer-dependencies/).

If a project adds (just) `"marked-man": "^0.2.1",` to devDependencies in its `package.json` then `npm` will just subtly complain that something is not correct

```shell
$ npm ls | grep marked
├─┬ marked-man@0.2.1
│ └── UNMET DEPENDENCY marked@0.3.19
npm ERR! missing: marked@0.3.19, required by marked-man@0.2.1
```

instead of properly complaining that there is an unmet peer dependency.


Tested by publishing a 0.3.1 version to a local [verdaccio](https://github.com/verdaccio/verdaccio) test repository which then makes npm install complain explicitly:

```shell
npm WARN marked-man@0.3.1 requires a peer of marked@^0.3.2 but none is installed. You must install peer dependencies yourself.
```

