### PR TITLE
fix #25 , move env process to bin/marked-man

### DIFF
--- a/bin/marked-man
+++ b/bin/marked-man
@@ -4,7 +4,14 @@ require('../'); // force bin/marked to require marked-man
 
 var main = require('marked/bin/marked');
 
-main(process.argv.slice(), function(err, code) {
-	if (err) throw err;
-	return process.exit(code || 0);
+var argv = process.argv.slice()
+
+if (process.env.SOURCE_DATE_EPOCH) {
+  var epochMs = Number(process.env.SOURCE_DATE_EPOCH) * 1000
+  argv.splice(2, 0, '--date', String(epochMs))
+}
+
+main(argv, function(err, code) {
+  if (err) throw err;
+  return process.exit(code || 0);
 });

--- a/lib/marked-man.js
+++ b/lib/marked-man.js
@@ -436,12 +436,9 @@ function rparseHeader(str, options) {
     + resc(text);
 }
 function manDate(date) {
-	var stamp = parseInt(date);
-	if (!isNaN(stamp) && stamp.toString().length == date.length) date = stamp;
+  var stamp = parseInt(date);
+  if (!isNaN(stamp) && stamp.toString().length == date.length) date = stamp;
   date = new Date(date);
-  if (process.env.SOURCE_DATE_EPOCH) {
-    date = new Date(process.env.SOURCE_DATE_EPOCH * 1000);
-  }
   var month = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"][date.getMonth()];
   return month + " " + date.getFullYear();
 }


### PR DESCRIPTION
commit #cfacf6d should fix #25  .
detect env in `lib/marked-man.js` require extra global variable `process` ,
make it hard to work with other module.
parsing option inside `bin/marked-man` is more reasonable.