### PR TITLE
Fix HTML entity conversion

### DIFF
--- a/lib/marked-man.js
+++ b/lib/marked-man.js
@@ -114,7 +114,7 @@ InlineLexer.prototype.roff_output = function(src) {
 		if ((cap = this.rules.code.exec(src))) {
 			src = src.substring(cap[0].length);
 			out += '\\fB'
-				+ resc(lastMatch(cap), true)
+				+ rescWithoutRentities(lastMatch(cap), true)
 				+ '\\fP';
 			continue;
 		}
@@ -221,7 +221,7 @@ Parser.prototype.roff_tok = function() {
 		}
 
 		if (!this.token.escaped) {
-			this.token.text = resc(this.token.text);
+			this.token.text = rescWithoutRentities(this.token.text);
 		}
 
 		return '.P\n'
@@ -373,32 +373,40 @@ function quote(str) {
 }
 
 function resc(str) {
+	return rentities(rescWithoutRentities(str));
+}
+
+function rescWithoutRentities(str) {
 	if (str == null) return "";
-	return rentities(str
+	return str
 	.replace(/\\/gm, "\\\\")
 	.replace(/-/gm, "\\-")
 	.replace(/^\./gm, "\\|.")
 	.replace(/\./gm, "\\.")
-	.replace(/^'/gm, "\\|'")).replace('&amp;', '&');
+	.replace(/^'/gm, "\\|'");
 }
 
 function rentities(str) {
 	return str.replace(/&(\w+);/gm, function(match, ent) {
 		var gr = {
-			bull: '[ci]',
-			nbsp: '~',
-			copy: '(co',
-			rdquo: '(rs',
-			mdash: '(em',
-			reg: '(rg',
-			sect: '(sc',
-			ge: '(>=',
-			le: '(<=',
-			ne: '(!=',
-			equiv: '(==',
-			plusmn: '(+-'
+			lt: '<',
+			gt: '>',
+			amp: '&',
+			quot: '"',
+			bull: '\\[ci]',
+			nbsp: '\\~',
+			copy: '\\(co',
+			rdquo: '\\(rs',
+			mdash: '\\(em',
+			reg: '\\(rg',
+			sect: '\\(sc',
+			ge: '\\(>=',
+			le: '\\(<=',
+			ne: '\\(!=',
+			equiv: '\\(==',
+			plusmn: '\\(+-'
 		}[ent];
-		if (gr) return '\\' + gr;
+		if (gr) return gr;
 		else return match;
 	});
 }

--- a/test/man/entity_encoding_test
+++ b/test/man/entity_encoding_test
@@ -2,7 +2,7 @@
 .SH "NAME"
 \fBhello\fR \- hello world
 .P
-Your output &lt;i&gt;might&lt;/i&gt; look like this:
+Your output <i>might</i> look like this:
 .P
 .RS 2
 .nf

--- a/test/man/markdown_syntax
+++ b/test/man/markdown_syntax
@@ -151,11 +151,11 @@ used to denote HTML entities\. If you want to use them as literal
 .br
 characters, you must escape them as entities, e\.g\. \fB&lt;\fP, and
 .br
-\fB&\fP\|\.
+\fB&amp;\fP\|\.
 .P
 Ampersands in particular are bedeviling for web writers\. If you want to
 .br
-write about 'AT&T', you need to write '\fBAT&T\fP\|'\. You even need to
+write about 'AT&T', you need to write '\fBAT&amp;T\fP\|'\. You even need to
 .br
 escape ampersands within URLs\. Thus, if you want to link to:
 .P
@@ -169,7 +169,7 @@ you need to encode the URL as:
 .P
 .RS 2
 .nf
-http://images\.google\.com/images?num=30&q=larry+bird
+http://images\.google\.com/images?num=30&amp;q=larry+bird
 .fi
 .RE
 .P
@@ -185,13 +185,13 @@ all the necessary escaping for you\. If you use an ampersand as part of
 .br
 an HTML entity, it remains unchanged; otherwise it will be translated
 .br
-into \fB&\fP\|\.
+into \fB&amp;\fP\|\.
 .P
 So, if you want to include a copyright symbol in your article, you can write:
 .P
 .RS 2
 .nf
-\(co
+&copy;
 .fi
 .RE
 .P
@@ -207,7 +207,7 @@ Markdown will translate it to:
 .P
 .RS 2
 .nf
-AT&T
+AT&amp;T
 .fi
 .RE
 .P
@@ -725,7 +725,7 @@ ampersands and angle brackets\. For example, this:
 .RS 2
 .nf
     <div class="footer">
-        \(co 2004 Foo Corporation
+        &copy; 2004 Foo Corporation
     </div>
 .fi
 .RE
@@ -735,7 +735,7 @@ will turn into:
 .RS 2
 .nf
 <pre><code>&lt;div class="footer"&gt;
-    &copy; 2004 Foo Corporation
+    &amp;copy; 2004 Foo Corporation
 &lt;/div&gt;
 </code></pre>
 .fi
@@ -1184,7 +1184,7 @@ You can write this:
 .P
 .RS 2
 .nf
-`&#8212;` is the decimal\-encoded equivalent of `\(em`\.
+`&#8212;` is the decimal\-encoded equivalent of `&mdash;`\.
 .fi
 .RE
 .P
@@ -1192,7 +1192,7 @@ to produce:
 .P
 .RS 2
 .nf
-<p><code>&#8212;</code> is the decimal\-encoded
+<p><code>&amp;#8212;</code> is the decimal\-encoded
 equivalent of <code>&amp;mdash;</code>\.</p>
 .fi
 .RE

--- a/test/out/entity_encoding_test
+++ b/test/out/entity_encoding_test
@@ -3,7 +3,7 @@ HELLO(1)                                                              HELLO(1)
 NNAAMMEE
        hheelllloo - hello world
 
-       Your output &lt;i&gt;might&lt;/i&gt; look like this:
+       Your output <i>might</i> look like this:
 
          * Chris
          *

--- a/test/out/markdown_syntax
+++ b/test/out/markdown_syntax
@@ -115,17 +115,17 @@ DDEESSCCRRIIPPTTIIOONN
        and &&. Left angle brackets are used to start tags; ampersands are
        used to denote HTML entities. If you want to use them as literal
        characters, you must escape them as entities, e.g. &&lltt;;, and
-       &&.
+       &&aammpp;;.
 
        Ampersands in particular are bedeviling for web writers. If you want to
-       write about 'AT&T', you need to write 'AATT&&TT'. You even need to
+       write about 'AT&T', you need to write 'AATT&&aammpp;;TT'. You even need to
        escape ampersands within URLs. Thus, if you want to link to:
 
          http://images.google.com/images?num=30&q=larry+bird
 
        you need to encode the URL as:
 
-         http://images.google.com/images?num=30&q=larry+bird
+         http://images.google.com/images?num=30&amp;q=larry+bird
 
        in your anchor tag hhrreeff attribute. Needless to say, this is easy to
        forget,  and  is probably the single most common source of HTML valida‐
@@ -135,12 +135,12 @@ DDEESSCCRRIIPPTTIIOONN
        Markdown allows you to use these characters naturally, taking care of
        all the necessary escaping for you. If you use an ampersand as part of
        an HTML entity, it remains unchanged; otherwise it will be translated
-       into &&.
+       into &&aammpp;;.
 
        So, if you want to include a copyright symbol in your article, you  can
        write:
 
-         ©
+         &copy;
 
        and Markdown will leave it alone. But if you write:
 
@@ -148,7 +148,7 @@ DDEESSCCRRIIPPTTIIOONN
 
        Markdown will translate it to:
 
-         AT&T
+         AT&amp;T
 
        Similarly, because Markdown supports inline HTML _#_h_t_m_l, if you use
        angle brackets as delimiters for HTML tags, Markdown will treat them as
@@ -482,13 +482,13 @@ BBLLOOCCKK EELLEEMMEENNTTSS
        ampersands and angle brackets. For example, this:
 
              <div class="footer">
-                 © 2004 Foo Corporation
+                 &copy; 2004 Foo Corporation
              </div>
 
        will turn into:
 
          <pre><code>&lt;div class="footer"&gt;
-             &copy; 2004 Foo Corporation
+             &amp;copy; 2004 Foo Corporation
          &lt;/div&gt;
          </code></pre>
 
@@ -756,11 +756,11 @@ SSPPAANN EELLEEMMEENNTTSS
 
        You can write this:
 
-         `&#8212;` is the decimal-encoded equivalent of `—`.
+         `&#8212;` is the decimal-encoded equivalent of `&mdash;`.
 
        to produce:
 
-         <p><code>&#8212;</code> is the decimal-encoded
+         <p><code>&amp;#8212;</code> is the decimal-encoded
          equivalent of <code>&amp;mdash;</code>.</p>
 
    IImmaaggeess


### PR DESCRIPTION
- Convert `&lt;` `&gt;` `&quot;`
- Do not convert in code

| Rendered in markdown | man page |
| --- | --- |
| `test/md/entity_encoding_test.md`<br>![image](https://user-images.githubusercontent.com/20474/100521563-decb3d80-31e7-11eb-839f-d2fac5ee73f3.png) | `test/man/entity_encoding_test`<br>Before<br>![image](https://user-images.githubusercontent.com/20474/100521596-03271a00-31e8-11eb-8a24-d2dbd97041eb.png)<br>After<br>![image](https://user-images.githubusercontent.com/20474/100521585-f1de0d80-31e7-11eb-88d0-c37d4e992baf.png) |
| `test/md/markdown_syntax.md`<br>![image](https://user-images.githubusercontent.com/20474/100521495-5c427e00-31e7-11eb-8f1b-1aaff8de254b.png) | `test/man/markdown_syntax`<br>Before<br>![image](https://user-images.githubusercontent.com/20474/100521502-71b7a800-31e7-11eb-9e51-37f31d26727f.png)<br>After<br>![image](https://user-images.githubusercontent.com/20474/100521517-97dd4800-31e7-11eb-85e7-91cc1666929b.png) |


