### PR TITLE
Make the output reproducible regardless of the system timezone

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -80,6 +80,7 @@ export function manDate(date) {
 	const stamp = parseInt(date);
 	if (!Number.isNaN(stamp) && stamp.toString().length == date.length) date = stamp;
 	date = new Date(date);
+	date = new Date(date.getTime() + date.getTimezoneOffset() * 60000);
 	return date.toLocaleString('en', { month: 'long', year: 'numeric' });
 }
 


### PR DESCRIPTION
Whilst working on the [Reproducible Builds](https://reproducible-builds.org/) effort, I noticed that marked-man generates its output nondeterministically if the value of `SOURCE_DATE_EPOCH` is within X hours of the end of the UTC month **and** the build system's timezone offset is greater than or equal to X hours.

You can see an [example on the Debian bug](https://bugs.debian.org/1030724#5).

The solution is to emit the output as UTC and not in the build system's timezone.