### PR TITLE
Fix: Missing spaces and other punctuation after inline links + .gitignore test/*-err folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules
-test/*/*.err
+test/*-err
 

--- a/src/extensions.js
+++ b/src/extensions.js
@@ -10,7 +10,7 @@ const link = {
 	name: 'link',
 	level: 'inline',
 	tokenizer(src, tokens) {
-		if (!tokens.length || /^\p{Po}/u.test(src) == false) return;
+		if (!tokens.length) return;
 		const tok = tokens[tokens.length - 1];
 		if (tok.type == "link") {
 			tok.punctuation = src.charAt(0);
@@ -20,6 +20,7 @@ const link = {
 	renderer({ href, title, text, punctuation }) {
 		if (href.startsWith('#')) {
 			// a local reference, not a link
+			if(punctuation==='\n') punctuation = '\n\.br\n';
 			return `\\fI${title || text || href.slice(1)}\\fR${punctuation || ''}`;
 		}
 		const obj = new URL(href, "file://./");


### PR DESCRIPTION
Punctuation following an internal link that is not matched by `\\p{Po}` was discarded, so e.g. `[link](#target) text` became `\fIlink\fRtext` => removing filter, so now rendering`\fIlink\fR text`.

In accordance to general handling, newline as punctuation is rendered as `.br`

In .gitignore obviously an older naming scheme for temporary test/*-err folders was addressed => update to current scheme